### PR TITLE
Set also `name` attribute in meta tag

### DIFF
--- a/web/app/public/index.html
+++ b/web/app/public/index.html
@@ -11,7 +11,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="shortcut icon" href="/favicon.ico" />
-    <meta property="description" content="Gatus is an advanced automated status page that lets you monitor your applications and configure alerts to notify you if there's an issue" />
+    <meta name="description" property="description" content="Gatus is an advanced automated status page that lets you monitor your applications and configure alerts to notify you if there's an issue" />
   </head>
   <body class="dark:bg-gray-900">
     <noscript><strong>Enable JavaScript to view this page.</strong></noscript>


### PR DESCRIPTION
Lighthouse (and probably other tools) do not detect `<meta property="description" ... >` but only `<meta name="description" ... >`. According to [this SO answer](https://stackoverflow.com/a/22418095/7196903), the latter is the standard HTML5 way to provide a site's description metadata, while the former is the RDFa way to do the same. According to [another SO answer](https://stackoverflow.com/a/20429551/7196903), it is absolutely valid to provide both attributes in the same meta tag, so here we go.